### PR TITLE
Add Info Message (when using version < python 3)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,8 @@
+from sys import version_info, exit
+#check python version
+if version_info.major < 3:
+    exit("Python 3.x is required to run this program")
+
 from os import path
 from builtins import open
 from setuptools import setup


### PR DESCRIPTION
[Refered to this Stackoverflow Question](https://stackoverflow.com/questions/13924931/setup-py-restrict-the-allowable-version-of-the-python-interpreter)
Implements #57